### PR TITLE
Branch voor discipline lijst

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,10 +6,7 @@
   </div>
   <div class="col-md-8">
     <app-person-detail></app-person-detail>
-    <div class="medal-chart">
-      <app-medal-chart [medalData]="medalData"></app-medal-chart>
-    </div>
-    <app-related-graphs></app-related-graphs>
+    <app-related-graphs style="margin-top: 50px;"></app-related-graphs>
   </div>
 </div>
 <router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -41,7 +41,7 @@ export class AppComponent implements OnInit, OnDestroy{
 
   private setMedalsData() {
     const countOccurrences = (arr, val) => arr.reduce((a, v) => (v.medal === val ? a + 1 : a), 0);
-    this._subscription = this.filteredDataService.selectedFilteredAthletesSubject.subscribe(
+    this._subscription = this.filteredDataService.selectedFilteredAthleteEntriesSubject.subscribe(
       fa => {
         if (fa) {
           let goldCount = countOccurrences(fa, "Gold");

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -41,14 +41,20 @@ export class AppComponent implements OnInit, OnDestroy{
 
   private setMedalsData() {
     const countOccurrences = (arr, val) => arr.reduce((a, v) => (v.medal === val ? a + 1 : a), 0);
-    this._subscription = this.filteredDataService.filteredAthletesSubject.subscribe(
+    this._subscription = this.filteredDataService.selectedFilteredAthletesSubject.subscribe(
       fa => {
-        let goldCount = countOccurrences(fa, "Gold");
-        //console.log('gold count is ' + goldCount);
-        let silverCount = countOccurrences(fa, "Silver");
-        //console.log('silver count is ' + silverCount);
-        let bronzeCount = countOccurrences(fa, "Bronze");
-        this.medalData = [goldCount, silverCount, bronzeCount];
+        if (fa) {
+          let goldCount = countOccurrences(fa, "Gold");
+          //console.log('gold count is ' + goldCount);
+          let silverCount = countOccurrences(fa, "Silver");
+          //console.log('silver count is ' + silverCount);
+          let bronzeCount = countOccurrences(fa, "Bronze");
+          this.medalData = [goldCount, silverCount, bronzeCount];
+        }
+        else {
+          this.medalData = [0,0,0];
+        }
+       
       }
     );
   }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { SelectionComponent } from './selection/selection.component';
 import { PersonDetailComponent } from './person-detail/person-detail.component';
 import { RelatedGraphCountryMedalsComponent } from './related-graph-country-medals/related-graph-country-medals.component';
 import { RelatedGraphsComponent } from './related-graphs/related-graphs.component';
+import { OlympicEntriesComponent } from './olympic-entries/olympic-entries.component';
 
 @NgModule({
   declarations: [
@@ -31,7 +32,8 @@ import { RelatedGraphsComponent } from './related-graphs/related-graphs.componen
     SelectionComponent,
     PersonDetailComponent,
     RelatedGraphCountryMedalsComponent,
-    RelatedGraphsComponent
+    RelatedGraphsComponent,
+    OlympicEntriesComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/filter.service.ts
+++ b/src/app/filter.service.ts
@@ -188,9 +188,6 @@ export class FilterService {
     this.filteredDataService.publishFilteredAthleteEntries(athleteEntries);
     this.filterAndPublishAthletesOnAllAttributesAndSelectedDiscipline(athleteEntries);
     this.filterAndPublishDisciplinesOnAllAttributesAndSelectedAthlete(athleteEntries);
-    // if (athleteEntries.length > 0) {
-    //   this.selectAthleteFromList(athleteEntries);
-    // }
   }
 
   filterAndPublishAthletesOnAllAttributesAndSelectedDiscipline(athleteEntries: AthleteEntry[]) {
@@ -258,8 +255,9 @@ export class FilterService {
       this._selectedAthlete = null;
       this.filteredDataService.filteredAthleteEntriesSubject.pipe(take(1)).subscribe((a: AthleteEntry[]) => {
         this.filterAndPublishDisciplinesOnAllAttributesAndSelectedAthlete(a);
-        this.filteredDataService.publishSelectedAthlete(null);
-        this.filteredDataService.publishSelectedFilteredAthletes(a.filter(ae => (!this._selectedAthlete || (this._selectedAthlete && this._selectedAthlete.name === ae.name)) && (!this._selectedDiscipline || (this._selectedDiscipline && this.disciplineEntriesEqual(ae.disciplineEntry, this._selectedDiscipline)))));
+        this.filteredDataService.publishSelectedAthlete(this._selectedAthlete);
+        let selectedFilteredAthletes = a.filter(ae => (!this._selectedAthlete || (this._selectedAthlete && this._selectedAthlete.name === ae.name)) && (!this._selectedDiscipline || (this._selectedDiscipline && this.disciplineEntriesEqual(ae.disciplineEntry, this._selectedDiscipline))));
+        this.filteredDataService.publishSelectedFilteredAthleteEntries(selectedFilteredAthletes);
       });
     }
     else {
@@ -267,8 +265,8 @@ export class FilterService {
       this._selectedAthlete = selectedAthlete;
       this.filteredDataService.filteredAthleteEntriesSubject.pipe(take(1)).subscribe((a: AthleteEntry[]) => {
         this.filterAndPublishDisciplinesOnAllAttributesAndSelectedAthlete(a);
-        this.filteredDataService.publishSelectedAthlete(selectedAthlete);
-        this.filteredDataService.publishSelectedFilteredAthletes(a.filter(ae => (!this._selectedAthlete || (this._selectedAthlete && this._selectedAthlete.name === ae.name)) && (!this._selectedDiscipline || (this._selectedDiscipline && this.disciplineEntriesEqual(ae.disciplineEntry, this._selectedDiscipline)))));
+        this.filteredDataService.publishSelectedAthlete(this._selectedAthlete);
+        this.filteredDataService.publishSelectedFilteredAthleteEntries(a.filter(ae => (!this._selectedAthlete || (this._selectedAthlete && this._selectedAthlete.name === ae.name)) && (!this._selectedDiscipline || (this._selectedDiscipline && this.disciplineEntriesEqual(ae.disciplineEntry, this._selectedDiscipline)))));
       });
     }
   }
@@ -278,16 +276,16 @@ export class FilterService {
       this._selectedDiscipline = null;
       this.filteredDataService.filteredAthleteEntriesSubject.pipe(take(1)).subscribe((a: AthleteEntry[]) => {
         this.filterAndPublishAthletesOnAllAttributesAndSelectedDiscipline(a);
-        this.filteredDataService.publishSelectedDiscipline(discipline);
-        this.filteredDataService.publishSelectedFilteredAthletes(a.filter(ae => (!this._selectedAthlete || (this._selectedAthlete && this._selectedAthlete.name === ae.name)) && (!this._selectedDiscipline || (this._selectedDiscipline && this.disciplineEntriesEqual(ae.disciplineEntry, this._selectedDiscipline)))));
+        this.filteredDataService.publishSelectedDiscipline(this._selectedDiscipline);
+        this.filteredDataService.publishSelectedFilteredAthleteEntries(a.filter(ae => (!this._selectedAthlete || (this._selectedAthlete && this._selectedAthlete.name === ae.name)) && (!this._selectedDiscipline || (this._selectedDiscipline && this.disciplineEntriesEqual(ae.disciplineEntry, this._selectedDiscipline)))));
       });
     }
     else {
       this._selectedDiscipline = discipline;
       this.filteredDataService.filteredAthleteEntriesSubject.pipe(take(1)).subscribe((a: AthleteEntry[]) => {
         this.filterAndPublishAthletesOnAllAttributesAndSelectedDiscipline(a);
-        this.filteredDataService.publishSelectedDiscipline(discipline);
-        this.filteredDataService.publishSelectedFilteredAthletes(a.filter(ae => (!this._selectedAthlete || (this._selectedAthlete && this._selectedAthlete.name === ae.name)) && (!this._selectedDiscipline || (this._selectedDiscipline && this.disciplineEntriesEqual(ae.disciplineEntry, this._selectedDiscipline)))));
+        this.filteredDataService.publishSelectedDiscipline(this._selectedDiscipline);
+        this.filteredDataService.publishSelectedFilteredAthleteEntries(a.filter(ae => (!this._selectedAthlete || (this._selectedAthlete && this._selectedAthlete.name === ae.name)) && (!this._selectedDiscipline || (this._selectedDiscipline && this.disciplineEntriesEqual(ae.disciplineEntry, this._selectedDiscipline)))));
       });
     }
   }

--- a/src/app/filter.service.ts
+++ b/src/app/filter.service.ts
@@ -7,6 +7,7 @@ import { Athlete } from 'src/models/athlete';
 import { ReplaySubject } from 'rxjs';
 import { AthleteEntry } from 'src/models/athlete-entry';
 import { take } from 'rxjs/operators';
+import { disciplineSortFunction } from 'src/helpers/discipline-sort-function';
 
 
 @Injectable({
@@ -86,6 +87,7 @@ export class FilterService {
       (csvData) => {
         this._originalCsvData = csvData;
         this.filteredDataService.publishFilteredAthletes(this._originalCsvData.athleteEntries);
+        this.filteredDataService.publishFilteredDisciplines(this._originalCsvData.disciplineEntries.sort(disciplineSortFunction));
         this.buildFilteredItems();
       });
 

--- a/src/app/filter.service.ts
+++ b/src/app/filter.service.ts
@@ -1,3 +1,4 @@
+import { DisciplineEntry } from './../models/discipline-entry';
 import { FilteredDataService } from './filtered-data.service';
 import { CsvService } from './csv.service';
 import { Injectable } from '@angular/core';
@@ -238,17 +239,27 @@ export class FilterService {
   private buildFilteredItems() {
     let countrySet = new Set<string>();
     let personSet = new Set<string>();
+    let disciplineSet: Set<string> = new Set<string>();
+    let disciplineEntries: DisciplineEntry[] = [];
+
     if (this._filteredAthletesSubsription$) {
       this._filteredAthletesSubsription$.unsubscribe();
     }
     this._filteredAthletesSubsription$ = this.filteredDataService.filteredAthletesSubject.subscribe(
       fa => {
         fa.forEach(athleteEntry => {
-          // countrySet.add(this.getRegionForNoc(athleteEntry.noc));
+          countrySet.add(this.getRegionForNoc(athleteEntry.noc));
           personSet.add(athleteEntry.name);
+
+          let disciplineString = `${athleteEntry.disciplineEntry.event}${athleteEntry.disciplineEntry.sport}${athleteEntry.disciplineEntry.sex}`;
+          if (!disciplineSet.has(disciplineString)) {
+            disciplineEntries.push(athleteEntry.disciplineEntry);
+            disciplineSet.add(disciplineString);
+          }
         });
-        this.filteredDataService.publishFilteredCountries([...countrySet]);
-        this.filteredDataService.publishFilteredPersons([...personSet]);
+        this.filteredDataService.publishfilteredCountries([...countrySet]);
+        this.filteredDataService.publishfilteredPersons([...personSet]);
+        this.filteredDataService.publishFilteredDisciplines([...disciplineEntries]);
       }
     )
   }

--- a/src/app/filter.service.ts
+++ b/src/app/filter.service.ts
@@ -1,10 +1,9 @@
-import { DisciplineEntry } from './../models/discipline-entry';
+import { DisciplineEntry } from 'src/models/discipline-entry';
 import { FilteredDataService } from './filtered-data.service';
 import { CsvService } from './csv.service';
 import { Injectable } from '@angular/core';
 import { CsvData } from 'src/models/csv-data';
 import { Athlete } from 'src/models/athlete';
-import { ReplaySubject } from 'rxjs';
 import { AthleteEntry } from 'src/models/athlete-entry';
 import { take } from 'rxjs/operators';
 import { disciplineSortFunction } from 'src/helpers/discipline-sort-function';
@@ -236,6 +235,10 @@ export class FilterService {
       }
     })
     return [bronzeList, silverList, goldList];
+  }
+
+  searchAndSelectFirstDiscipline(discipline: DisciplineEntry) {
+    console.log(discipline.event);
   }
 
   private buildFilteredItems() {

--- a/src/app/filter.service.ts
+++ b/src/app/filter.service.ts
@@ -15,10 +15,18 @@ import { disciplineSortFunction } from 'src/helpers/discipline-sort-function';
 export class FilterService {
   private _originalCsvData: CsvData;
   private _selectAthleteFromListSubscription$;
-  private _selectedAthlete: Athlete;
-  private _selectedDiscipline: DisciplineEntry;
 
   //Dit zijn velden specifiek voor de filter. Hierop kunnen de properties in de view zich binden
+  private _selectedAthlete: Athlete;
+  public get selectedAthlete(): Athlete {
+    return this._selectedAthlete;
+  }
+
+  private _selectedDiscipline: DisciplineEntry;
+  public get selectedDiscipline(): DisciplineEntry {
+    return this._selectedDiscipline;
+  }
+
   private _countrySuggestions: string[] = [];
   public get countrySuggestions(): string[] {
     return this._countrySuggestions;
@@ -185,6 +193,8 @@ export class FilterService {
       }
       return true;
     });
+    this.filteredDataService.publishChosenEdition(this._chosenEdition);
+    this.filteredDataService.publishChosenSex(this.chosenSex);
     this.filteredDataService.publishFilteredAthleteEntries(athleteEntries);
     this.filterAndPublishAthletesOnAllAttributesAndSelectedDiscipline(athleteEntries);
     this.filterAndPublishDisciplinesOnAllAttributesAndSelectedAthlete(athleteEntries);
@@ -290,11 +300,11 @@ export class FilterService {
     }
   }
 
-  calculateMedalsForCountryForYearRange(country: string, startYear: number, endYear: number): [Map<number, number>, Map<number, number>, Map<number, number>] {
+  calculateMedalsForCountryForYearRange(country: string, startYear: number, endYear: number, selectedDiscipline: DisciplineEntry, season: string, chosenSex: string): [Map<number, number>, Map<number, number>, Map<number, number>] {
     let bronzeList: Map<number, number> = new Map<number, number>();
     let silverList: Map<number, number> = new Map<number, number>();
     let goldList: Map<number, number> = new Map<number, number>();
-    let countryAtheteEntries: AthleteEntry[] = this._originalCsvData.athleteEntries.filter(athleteEntry => athleteEntry.noc === country && athleteEntry.year >= startYear && athleteEntry.year <= endYear);
+    let countryAtheteEntries: AthleteEntry[] = this._originalCsvData.athleteEntries.filter(athleteEntry => (!season || season === 'all' || athleteEntry.season === season) && athleteEntry.noc === country && athleteEntry.year >= startYear && athleteEntry.year <= endYear && (!selectedDiscipline || athleteEntry.disciplineEntry.equals(selectedDiscipline)));
     countryAtheteEntries.map(countryAtheteEntry => {
       let entryYear = countryAtheteEntry.year;
       if (countryAtheteEntry.medal === "Bronze") {

--- a/src/app/filter.service.ts
+++ b/src/app/filter.service.ts
@@ -244,7 +244,7 @@ export class FilterService {
     this._filteredAthletesSubsription$ = this.filteredDataService.filteredAthletesSubject.subscribe(
       fa => {
         fa.forEach(athleteEntry => {
-          countrySet.add(this.getRegionForNoc(athleteEntry.noc));
+          // countrySet.add(this.getRegionForNoc(athleteEntry.noc));
           personSet.add(athleteEntry.name);
         });
         this.filteredDataService.publishFilteredCountries([...countrySet]);

--- a/src/app/filter.service.ts
+++ b/src/app/filter.service.ts
@@ -88,7 +88,7 @@ export class FilterService {
         this._originalCsvData = csvData;
         this.filteredDataService.publishFilteredAthleteEntries(this._originalCsvData.athleteEntries);
         this.filteredDataService.publishFilteredDisciplines(this._originalCsvData.disciplineEntries.sort(disciplineSortFunction));
-        this.filterAthletesOnAllAttributes(this._originalCsvData.athleteEntries);
+        this.filterAndPublishAthletesOnAllAttributesAndSelectedDiscipline(this._originalCsvData.athleteEntries);
         this.filterAndPublishDisciplinesOnAllAttributesAndSelectedAthlete(this._originalCsvData.athleteEntries);
       });
 
@@ -186,20 +186,30 @@ export class FilterService {
       return true;
     });
     this.filteredDataService.publishFilteredAthleteEntries(athleteEntries);
-    this.filterAthletesOnAllAttributes(athleteEntries);
+    this.filterAndPublishAthletesOnAllAttributesAndSelectedDiscipline(athleteEntries);
     this.filterAndPublishDisciplinesOnAllAttributesAndSelectedAthlete(athleteEntries);
     if (athleteEntries.length > 0) {
       this.selectAthleteFromList(athleteEntries);
     }
   }
 
-  filterAthletesOnAllAttributes(athleteEntries: AthleteEntry[]) {
+  filterAndPublishAthletesOnAllAttributesAndSelectedDiscipline(athleteEntries: AthleteEntry[]) {
     let athleteSet: Set<string> = new Set<string>();
     let athletes: Athlete[] = [];
     athleteEntries.forEach((athleteEntry: AthleteEntry) => {
-      if (!athleteSet.has(athleteEntry.name)) {
-        athleteSet.add(athleteEntry.name);
-        athletes.push(new Athlete(athleteEntry.id, athleteEntry.name, athleteEntry.sex, athleteEntry.year - athleteEntry.age, athleteEntry.height, athleteEntry.weight, athleteEntry.noc));
+      if (this._selectedDiscipline) {
+        if (this._selectedDiscipline.equals(athleteEntry.disciplineEntry)) {
+          if (!athleteSet.has(athleteEntry.name)) {
+            athleteSet.add(athleteEntry.name);
+            athletes.push(new Athlete(athleteEntry.id, athleteEntry.name, athleteEntry.sex, athleteEntry.year - athleteEntry.age, athleteEntry.height, athleteEntry.weight, athleteEntry.noc));
+          }
+        }
+      }
+      else {
+        if (!athleteSet.has(athleteEntry.name)) {
+          athleteSet.add(athleteEntry.name);
+          athletes.push(new Athlete(athleteEntry.id, athleteEntry.name, athleteEntry.sex, athleteEntry.year - athleteEntry.age, athleteEntry.height, athleteEntry.weight, athleteEntry.noc));
+        }
       }
     });
     this.filteredDataService.publishFilteredAthletes(athletes);
@@ -245,7 +255,7 @@ export class FilterService {
       this.filteredDataService.filteredAthleteEntriesSubject.pipe(take(1)).subscribe((a: AthleteEntry[]) => {
         this.filterAndPublishDisciplinesOnAllAttributesAndSelectedAthlete(a);
         this.filteredDataService.publishSelectedAthlete(null);
-        this.filteredDataService.publishSelectedFilteredAthletes(a.filter(ae => !this._selectedDiscipline || ae.disciplineEntry.equals(this._selectedDiscipline)));
+        this.filteredDataService.publishSelectedFilteredAthletes(a.filter(ae => (!this._selectedAthlete || (this._selectedAthlete && this._selectedAthlete.name === ae.name)) && (!this._selectedDiscipline || (this._selectedDiscipline && ae.disciplineEntry.equals(this._selectedDiscipline)))));
       });
     }
     else {
@@ -254,7 +264,7 @@ export class FilterService {
       this.filteredDataService.filteredAthleteEntriesSubject.pipe(take(1)).subscribe((a: AthleteEntry[]) => {
         this.filterAndPublishDisciplinesOnAllAttributesAndSelectedAthlete(a);
         this.filteredDataService.publishSelectedAthlete(selectedAthlete);
-        this.filteredDataService.publishSelectedFilteredAthletes(a.filter(ae => ae.name === this._selectedAthlete.name && (!this._selectedDiscipline || ae.disciplineEntry.equals(this._selectedDiscipline))));
+        this.filteredDataService.publishSelectedFilteredAthletes(a.filter(ae => (!this._selectedAthlete || (this._selectedAthlete && this._selectedAthlete.name === ae.name)) && (!this._selectedDiscipline || (this._selectedDiscipline && ae.disciplineEntry.equals(this._selectedDiscipline)))));
       });
     }
     // if (selectedAthlete.id === this._selectedAthlete?.id) {
@@ -275,6 +285,46 @@ export class FilterService {
 
   }
 
+  searchAndSelectFirstDiscipline(discipline: DisciplineEntry) {
+    if (this._selectedDiscipline && this._selectedDiscipline.equals(discipline)) {
+      this._selectedDiscipline = null;
+      this.filteredDataService.filteredAthleteEntriesSubject.pipe(take(1)).subscribe((a: AthleteEntry[]) => {
+        this.filterAndPublishAthletesOnAllAttributesAndSelectedDiscipline(a);
+        this.filteredDataService.publishSelectedDiscipline(discipline);
+        this.filteredDataService.publishSelectedFilteredAthletes(a.filter(ae => (!this._selectedAthlete || (this._selectedAthlete && this._selectedAthlete.name === ae.name)) && (!this._selectedDiscipline || (this._selectedDiscipline && ae.disciplineEntry.equals(this._selectedDiscipline)))));
+      });
+    }
+    else {
+      this._selectedDiscipline = discipline;
+      this.filteredDataService.filteredAthleteEntriesSubject.pipe(take(1)).subscribe((a: AthleteEntry[]) => {
+        this.filterAndPublishAthletesOnAllAttributesAndSelectedDiscipline(a);
+        this.filteredDataService.publishSelectedDiscipline(discipline);
+        this.filteredDataService.publishSelectedFilteredAthletes(a.filter(ae => (!this._selectedAthlete || (this._selectedAthlete && this._selectedAthlete.name === ae.name)) && (!this._selectedDiscipline || (this._selectedDiscipline && ae.disciplineEntry.equals(this._selectedDiscipline)))));
+      });
+    }
+    // if (this._selectedDiscipline && this._selectedDiscipline.event === discipline.event && this._selectedDiscipline.sex === discipline.sex && this._selectedDiscipline.sport === discipline.sport) {
+    //   this.filteredDataService.publishSelectedDiscipline(null);
+    //   this.searchAndSelectFirstAthleteEntryByName(this._selectedAthlete.name);
+    // }
+    // else {
+    //   this.filteredDataService.publishSelectedDiscipline(discipline);
+    //   this.filteredDataService.filteredAthleteEntriesSubject.pipe(take(1)).subscribe( // take(1) is HEEL belangrijk hier. Anders komen we in een infinite loop terecht omdat de subscribe methode anders blijft uitgevoerd worden omdat we in deze subscribe methode zelf ook entries publishen op de subject. take(1) zorgt ervoor dat de subscribe maar max 1 keer gedaan wordt.
+    //     athleteEntries => { // We gebruiken hier de athleteEntries komende van de filteredAthletesSubject i.p.v. uit de csv. Anders voldoet de tabel met medaille-entries niet aan de filter.
+    //       let entries = athleteEntries.filter((athleteEntry: AthleteEntry) => athleteEntry.disciplineEntry.equals(discipline));
+    //       this.filteredDataService.publishSelectedAthlete(null);
+    //       this.filteredDataService.publishSelectedFilteredAthletes(null);
+    //       this.filteredDataService.publishFilteredAthleteEntries(entries);
+    //       this._selectedAthlete = null;
+    //       this.filterAthletesOnAllAttributes(athleteEntries);
+    //       this.filterAndPublishDisciplinesOnAllAttributesAndSelectedAthlete(athleteEntries);
+    //       if (athleteEntries.length > 0) {
+    //         this.selectAthleteFromList(athleteEntries);
+    //       }
+    //     }
+    //   );
+    // }
+  }
+
   calculateMedalsForCountryForYearRange(country: string, startYear: number, endYear: number): [Map<number, number>, Map<number, number>, Map<number, number>] {
     let bronzeList: Map<number, number> = new Map<number, number>();
     let silverList: Map<number, number> = new Map<number, number>();
@@ -291,30 +341,6 @@ export class FilterService {
       }
     })
     return [bronzeList, silverList, goldList];
-  }
-
-  searchAndSelectFirstDiscipline(discipline: DisciplineEntry) {
-    if (this._selectedDiscipline && this._selectedDiscipline.event === discipline.event && this._selectedDiscipline.sex === discipline.sex && this._selectedDiscipline.sport === discipline.sport) {
-      this.filteredDataService.publishSelectedDiscipline(null);
-      this.searchAndSelectFirstAthleteEntryByName(this._selectedAthlete.name);
-    }
-    else {
-      this.filteredDataService.publishSelectedDiscipline(discipline);
-      this.filteredDataService.filteredAthleteEntriesSubject.pipe(take(1)).subscribe( // take(1) is HEEL belangrijk hier. Anders komen we in een infinite loop terecht omdat de subscribe methode anders blijft uitgevoerd worden omdat we in deze subscribe methode zelf ook entries publishen op de subject. take(1) zorgt ervoor dat de subscribe maar max 1 keer gedaan wordt.
-        athleteEntries => { // We gebruiken hier de athleteEntries komende van de filteredAthletesSubject i.p.v. uit de csv. Anders voldoet de tabel met medaille-entries niet aan de filter.
-          let entries = athleteEntries.filter((athleteEntry: AthleteEntry) => athleteEntry.disciplineEntry.equals(discipline));
-          this.filteredDataService.publishSelectedAthlete(null);
-          this.filteredDataService.publishSelectedFilteredAthletes(null);
-          this.filteredDataService.publishFilteredAthleteEntries(entries);
-          this._selectedAthlete = null;
-          this.filterAthletesOnAllAttributes(athleteEntries);
-          this.filterAndPublishDisciplinesOnAllAttributesAndSelectedAthlete(athleteEntries);
-          if (athleteEntries.length > 0) {
-            this.selectAthleteFromList(athleteEntries);
-          }
-        }
-      );
-    }
   }
 
   private athleteBelongsToListOfCountries(athleteEntry, countriesToFilterOn): boolean {

--- a/src/app/filtered-data.service.ts
+++ b/src/app/filtered-data.service.ts
@@ -18,6 +18,11 @@ export class FilteredDataService {
   public get filteredAthletesSubject(): ReplaySubject<AthleteEntry[]> {
     return this._filteredAthletesSubject;
   }
+
+  private _filteredAthletes2Subject: ReplaySubject<Athlete[]> = new ReplaySubject<Athlete[]>(1);
+  public get filteredAthletes2Subject(): ReplaySubject<Athlete[]> {
+    return this._filteredAthletes2Subject;
+  }
   
   //Dit zijn de AthleteEntries van de GESELECTEERDE athleet die voldoen aan de gekozen filters.
   private _selectedFilteredAthletesSubject: ReplaySubject<AthleteEntry[]> = new ReplaySubject<AthleteEntry[]>(1);
@@ -28,11 +33,6 @@ export class FilteredDataService {
   private _filteredCountriesSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
   public get filteredCountriesSubject(): ReplaySubject<string[]> {
     return this._filteredCountriesSubject;
-  }
-
-  private _filteredPersonsSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
-  public get filteredPersonsSubject(): ReplaySubject<string[]> {
-    return this._filteredPersonsSubject;
   }
 
   private _selectedAthleteSubject: ReplaySubject<Athlete> = new ReplaySubject<Athlete>(1);
@@ -60,6 +60,10 @@ export class FilteredDataService {
     this._filteredAthletesSubject.next(athletes);
   }
 
+  public publishFilteredAthletes2(athletes: Athlete[]) {
+    this._filteredAthletes2Subject.next(athletes);
+  }
+
   public publishSelectedFilteredAthletes(selectedFilteredAthletes: AthleteEntry[]) {
     this._selectedFilteredAthletesSubject.next(selectedFilteredAthletes);
   }
@@ -78,10 +82,6 @@ export class FilteredDataService {
 
   public publishfilteredCountries(countries: string[]) {
     this._filteredCountriesSubject.next(countries);
-  }
-
-  public publishfilteredPersons(persons: string[]) {
-    this._filteredPersonsSubject.next(persons);
   }
 
   constructor() { }

--- a/src/app/filtered-data.service.ts
+++ b/src/app/filtered-data.service.ts
@@ -25,9 +25,9 @@ export class FilteredDataService {
   }
   
   //Dit zijn de AthleteEntries van de GESELECTEERDE athleet die voldoen aan de gekozen filters.
-  private _selectedFilteredAthletesSubject: ReplaySubject<AthleteEntry[]> = new ReplaySubject<AthleteEntry[]>(1);
-  public get selectedFilteredAthletesSubject(): ReplaySubject<AthleteEntry[]> {
-    return this._selectedFilteredAthletesSubject;
+  private _selectedFilteredAthleteEntriesSubject: ReplaySubject<AthleteEntry[]> = new ReplaySubject<AthleteEntry[]>(1);
+  public get selectedFilteredAthleteEntriesSubject(): ReplaySubject<AthleteEntry[]> {
+    return this._selectedFilteredAthleteEntriesSubject;
   }
 
   private _filteredCountriesSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
@@ -64,8 +64,8 @@ export class FilteredDataService {
     this._filteredAthletesSubject.next(athletes);
   }
 
-  public publishSelectedFilteredAthletes(selectedFilteredAthletes: AthleteEntry[]) {
-    this._selectedFilteredAthletesSubject.next(selectedFilteredAthletes);
+  public publishSelectedFilteredAthleteEntries(selectedFilteredAthletes: AthleteEntry[]) {
+    this._selectedFilteredAthleteEntriesSubject.next(selectedFilteredAthletes);
   }
 
   public publishSelectedAthlete(selectedAthlete: Athlete) {

--- a/src/app/filtered-data.service.ts
+++ b/src/app/filtered-data.service.ts
@@ -14,14 +14,14 @@ export class FilteredDataService {
   //Subscriptions waarop components zich kunnen subscriben om op de hoogte gebracht te worden van dataveranderingen.
 
   // Dit zijn ALLE AthleteEntries die voldoen aan de gekozen filters (voor alle Athleten dus)
-  private _filteredAthletesSubject: ReplaySubject<AthleteEntry[]> = new ReplaySubject<AthleteEntry[]>(1);
-  public get filteredAthletesSubject(): ReplaySubject<AthleteEntry[]> {
-    return this._filteredAthletesSubject;
+  private _filteredAthleteEntriesSubject: ReplaySubject<AthleteEntry[]> = new ReplaySubject<AthleteEntry[]>(1);
+  public get filteredAthleteEntriesSubject(): ReplaySubject<AthleteEntry[]> {
+    return this._filteredAthleteEntriesSubject;
   }
 
-  private _filteredAthletes2Subject: ReplaySubject<Athlete[]> = new ReplaySubject<Athlete[]>(1);
-  public get filteredAthletes2Subject(): ReplaySubject<Athlete[]> {
-    return this._filteredAthletes2Subject;
+  private _filteredAthletesSubject: ReplaySubject<Athlete[]> = new ReplaySubject<Athlete[]>(1);
+  public get filteredAthletesSubject(): ReplaySubject<Athlete[]> {
+    return this._filteredAthletesSubject;
   }
   
   //Dit zijn de AthleteEntries van de GESELECTEERDE athleet die voldoen aan de gekozen filters.
@@ -56,12 +56,12 @@ export class FilteredDataService {
   }
 
   //Methodes om nieuwe DataWaarden te publishen zodat de components die op de subscriptions gesubscribed zijn geupdatet worden.
-  public publishFilteredAthletes(athletes: AthleteEntry[]) {
-    this._filteredAthletesSubject.next(athletes);
+  public publishFilteredAthleteEntries(athletes: AthleteEntry[]) {
+    this._filteredAthleteEntriesSubject.next(athletes);
   }
 
-  public publishFilteredAthletes2(athletes: Athlete[]) {
-    this._filteredAthletes2Subject.next(athletes);
+  public publishFilteredAthletes(athletes: Athlete[]) {
+    this._filteredAthletesSubject.next(athletes);
   }
 
   public publishSelectedFilteredAthletes(selectedFilteredAthletes: AthleteEntry[]) {

--- a/src/app/filtered-data.service.ts
+++ b/src/app/filtered-data.service.ts
@@ -24,17 +24,16 @@ export class FilteredDataService {
   public get selectedFilteredAthletesSubject(): ReplaySubject<AthleteEntry[]> {
     return this._selectedFilteredAthletesSubject;
   }
-  
 
-  // private _filteredCountriesSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
-  // public get filteredCountriesSubject(): ReplaySubject<string[]>  {
-  //   return this._filteredCountriesSubject;
-  // }
+  private _filteredCountriesSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
+  public get filteredCountriesSubject(): ReplaySubject<string[]> {
+    return this._filteredCountriesSubject;
+  }
 
-  // private _filteredPersonsSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
-  // public get filteredPersonsSubject(): ReplaySubject<string[]> {
-  //   return this._filteredPersonsSubject;
-  // }
+  private _filteredPersonsSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
+  public get filteredPersonsSubject(): ReplaySubject<string[]> {
+    return this._filteredPersonsSubject;
+  }
 
   private _selectedAthleteSubject: ReplaySubject<Athlete> = new ReplaySubject<Athlete>(1);
   public get selectedAthleteSubject(): ReplaySubject<Athlete> {
@@ -65,14 +64,6 @@ export class FilteredDataService {
     this._selectedFilteredAthletesSubject.next(selectedFilteredAthletes);
   }
 
-  // public publishFilteredCountries(countries: string[]) {
-  //   this._filteredCountriesSubject.next(countries);
-  // }
-
-  // public publishFilteredPersons(persons: string[]) {
-  //   this._filteredPersonsSubject.next(persons);
-  // }
-
   public publishSelectedAthlete(selectedAthlete: Athlete) {
     this._selectedAthleteSubject.next(selectedAthlete);
   }
@@ -85,8 +76,12 @@ export class FilteredDataService {
     this._selectedDisciplinesSubject.next(discipline);
   }
 
-  public publishfilteredNOCRegions(nocRegions: NOCRegionEntry[]) {
-    this.filteredNOCRegions.next(nocRegions);
+  public publishfilteredCountries(countries: string[]) {
+    this._filteredCountriesSubject.next(countries);
+  }
+
+  public publishfilteredPersons(persons: string[]) {
+    this._filteredPersonsSubject.next(persons);
   }
 
   constructor() { }

--- a/src/app/filtered-data.service.ts
+++ b/src/app/filtered-data.service.ts
@@ -10,7 +10,6 @@ import { Athlete } from 'src/models/athlete';
   providedIn: 'root'
 })
 export class FilteredDataService {
-
   //Subscriptions waarop components zich kunnen subscriben om op de hoogte gebracht te worden van dataveranderingen.
 
   // Dit zijn ALLE AthleteEntries die voldoen aan de gekozen filters (voor alle Athleten dus)
@@ -19,11 +18,21 @@ export class FilteredDataService {
     return this._filteredAthleteEntriesSubject;
   }
 
+  private _chosenEditionSubject: ReplaySubject<string> = new ReplaySubject<string>(1);
+  public get chosenEditionSubject(): ReplaySubject<string> {
+    return this._chosenEditionSubject;
+  }
+
+  private _chosenSexSubject: ReplaySubject<string> = new ReplaySubject<string>(1);
+  public get chosenSexSubject(): ReplaySubject<string> {
+    return this._chosenSexSubject;
+  }
+
   private _filteredAthletesSubject: ReplaySubject<Athlete[]> = new ReplaySubject<Athlete[]>(1);
   public get filteredAthletesSubject(): ReplaySubject<Athlete[]> {
     return this._filteredAthletesSubject;
   }
-  
+
   //Dit zijn de AthleteEntries van de GESELECTEERDE athleet die voldoen aan de gekozen filters.
   private _selectedFilteredAthleteEntriesSubject: ReplaySubject<AthleteEntry[]> = new ReplaySubject<AthleteEntry[]>(1);
   public get selectedFilteredAthleteEntriesSubject(): ReplaySubject<AthleteEntry[]> {
@@ -82,6 +91,14 @@ export class FilteredDataService {
 
   public publishfilteredCountries(countries: string[]) {
     this._filteredCountriesSubject.next(countries);
+  }
+
+  public publishChosenEdition(chosenEdition: string) {
+    this._chosenEditionSubject.next(chosenEdition)
+  }
+
+  public publishChosenSex(chosenSex: string) {
+    this._chosenSexSubject.next(chosenSex)
   }
 
   constructor() { }

--- a/src/app/filtered-data.service.ts
+++ b/src/app/filtered-data.service.ts
@@ -1,3 +1,5 @@
+import { NOCRegionEntry } from 'src/models/noc-region-entry';
+import { DisciplineEntry } from './../models/discipline-entry';
 import { Injectable } from '@angular/core';
 import { ReplaySubject } from 'rxjs';
 import { AthleteEntry } from 'src/models/athlete-entry';
@@ -24,21 +26,35 @@ export class FilteredDataService {
   }
   
 
-  private _filteredCountriesSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
-  public get filteredCountriesSubject(): ReplaySubject<string[]>  {
-    return this._filteredCountriesSubject;
-  }
+  // private _filteredCountriesSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
+  // public get filteredCountriesSubject(): ReplaySubject<string[]>  {
+  //   return this._filteredCountriesSubject;
+  // }
 
-  private _filteredPersonsSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
-  public get filteredPersonsSubject(): ReplaySubject<string[]> {
-    return this._filteredPersonsSubject;
-  }
+  // private _filteredPersonsSubject: ReplaySubject<string[]> = new ReplaySubject<string[]>(1);
+  // public get filteredPersonsSubject(): ReplaySubject<string[]> {
+  //   return this._filteredPersonsSubject;
+  // }
 
   private _selectedAthleteSubject: ReplaySubject<Athlete> = new ReplaySubject<Athlete>(1);
   public get selectedAthleteSubject(): ReplaySubject<Athlete> {
     return this._selectedAthleteSubject;
   }
 
+  private _filteredDisciplinesSubject: ReplaySubject<DisciplineEntry[]> = new ReplaySubject<DisciplineEntry[]>(1);
+  public get filteredDisciplinesSubject(): ReplaySubject<DisciplineEntry[]> {
+    return this._filteredDisciplinesSubject;
+  }
+
+  private _selectedDisciplinesSubject: ReplaySubject<DisciplineEntry> = new ReplaySubject<DisciplineEntry>(1);
+  public get selectedDisciplinesSubject(): ReplaySubject<DisciplineEntry> {
+    return this._selectedDisciplinesSubject;
+  }
+
+  private _filteredNOCRegions: ReplaySubject<NOCRegionEntry[]> = new ReplaySubject<NOCRegionEntry[]>(1);
+  public get filteredNOCRegions(): ReplaySubject<NOCRegionEntry[]> {
+    return this._filteredNOCRegions;
+  }
 
   //Methodes om nieuwe DataWaarden te publishen zodat de components die op de subscriptions gesubscribed zijn geupdatet worden.
   public publishFilteredAthletes(athletes: AthleteEntry[]) {
@@ -49,16 +65,28 @@ export class FilteredDataService {
     this._selectedFilteredAthletesSubject.next(selectedFilteredAthletes);
   }
 
-  public publishFilteredCountries(countries: string[]) {
-    this._filteredCountriesSubject.next(countries);
-  }
+  // public publishFilteredCountries(countries: string[]) {
+  //   this._filteredCountriesSubject.next(countries);
+  // }
 
-  public publishFilteredPersons(persons: string[]) {
-    this.filteredPersonsSubject.next(persons);
-  }
+  // public publishFilteredPersons(persons: string[]) {
+  //   this._filteredPersonsSubject.next(persons);
+  // }
 
   public publishSelectedAthlete(selectedAthlete: Athlete) {
-    this.selectedAthleteSubject.next(selectedAthlete);
+    this._selectedAthleteSubject.next(selectedAthlete);
+  }
+
+  public publishFilteredDisciplines(disciplines: DisciplineEntry[]) {
+    this._filteredDisciplinesSubject.next(disciplines);
+  }
+
+  public publishSelectedDiscipline(discipline: DisciplineEntry) {
+    this._selectedDisciplinesSubject.next(discipline);
+  }
+
+  public publishfilteredNOCRegions(nocRegions: NOCRegionEntry[]) {
+    this.filteredNOCRegions.next(nocRegions);
   }
 
   constructor() { }

--- a/src/app/medal-chart/medal-chart.component.ts
+++ b/src/app/medal-chart/medal-chart.component.ts
@@ -28,7 +28,7 @@ export class MedalChartComponent implements OnInit, OnChanges {
 
   ngOnInit(): void {
     const countOccurrences = (arr, val) => arr.reduce((a, v) => (v.medal === val ? a + 1 : a), 0);
-    this._subscription = this.filteredDataService.selectedFilteredAthletesSubject.subscribe(
+    this._subscription = this.filteredDataService.selectedFilteredAthleteEntriesSubject.subscribe(
       fa => {
         console.log("Counting medals..");
         let goldCount = countOccurrences(fa, "Gold");

--- a/src/app/olympic-entries/olympic-entries.component.html
+++ b/src/app/olympic-entries/olympic-entries.component.html
@@ -1,5 +1,5 @@
 <h5>Olympic entries</h5>
-            <p-table [value]="filteredDataService.selectedFilteredAthletesSubject | async" sortField="year" [sortOrder]="-1" sortMode="single" [scrollable]="true" scrollHeight="400px" rowGroupMode="subheader" responsiveLayout="scroll">
+            <p-table [value]="selectedFilteredAthleteEntries" sortField="year" [sortOrder]="-1" sortMode="single" [scrollable]="true" scrollHeight="400px" rowGroupMode="subheader" responsiveLayout="scroll">
                 <ng-template pTemplate="header">
                     <tr>
                         <th pSortableColumn="year" style="min-width:20px">Year <p-sortIcon field="year"></p-sortIcon></th>
@@ -14,7 +14,7 @@
                         <td style="min-width: 80%">
                             <div style="text-align: right; width: 100%">Total entries: </div>
                         </td>
-                        <td style="width: 20%">{{(filteredDataService.selectedFilteredAthletesSubject | async)?.length}}</td>
+                        <td style="width: 20%">{{(selectedFilteredAthleteEntries)?.length}}</td>
                     </tr>
                 </ng-template>
                 <ng-template pTemplate="body" let-athleteEntry let-rowIndex="rowIndex">
@@ -26,10 +26,10 @@
                             {{athleteEntry.city}}
                         </td>
                         <td style="min-width:250px">
-                            {{athleteEntry.sport}}
+                            {{athleteEntry.disciplineEntry.sport}}
                         </td>
                         <td style="min-width:350px">
-                            {{athleteEntry.event}}
+                            {{athleteEntry.disciplineEntry.event}}
                         </td>
                         <td style="min-width:25px">
                             <span class="medal-icon" [ngClass]="{'bronze': athleteEntry.medal === 'Bronze', 'silver': athleteEntry.medal === 'Silver', 'gold': athleteEntry.medal === 'Gold' }"></span>

--- a/src/app/olympic-entries/olympic-entries.component.html
+++ b/src/app/olympic-entries/olympic-entries.component.html
@@ -1,0 +1,39 @@
+<h5>Olympic entries</h5>
+            <p-table [value]="filteredDataService.selectedFilteredAthletesSubject | async" sortField="year" [sortOrder]="-1" sortMode="single" [scrollable]="true" scrollHeight="400px" rowGroupMode="subheader" responsiveLayout="scroll">
+                <ng-template pTemplate="header">
+                    <tr>
+                        <th pSortableColumn="year" style="min-width:20px">Year <p-sortIcon field="year"></p-sortIcon></th>
+                        <th pSortableColumn="city" style="min-width:50px">City <p-sortIcon field="city"></p-sortIcon></th>
+                        <th pSortableColumn="sport" style="min-width:250px">Sport <p-sortIcon field="sport"></p-sortIcon></th>
+                        <th pSortableColumn="event" style="min-width:350px">Event <p-sortIcon field="event"></p-sortIcon></th>
+                        <th style="min-width:25px">Medal</th>
+                    </tr>
+                </ng-template>
+                <ng-template pTemplate="groupfooter" let-athleteEntry>
+                    <tr class="p-rowgroup-footer">
+                        <td style="min-width: 80%">
+                            <div style="text-align: right; width: 100%">Total entries: </div>
+                        </td>
+                        <td style="width: 20%">{{(filteredDataService.selectedFilteredAthletesSubject | async)?.length}}</td>
+                    </tr>
+                </ng-template>
+                <ng-template pTemplate="body" let-athleteEntry let-rowIndex="rowIndex">
+                    <tr>
+                        <td style="min-width:20px">
+                            {{athleteEntry.year}}
+                        </td>
+                        <td style="min-width:50px">
+                            {{athleteEntry.city}}
+                        </td>
+                        <td style="min-width:250px">
+                            {{athleteEntry.sport}}
+                        </td>
+                        <td style="min-width:350px">
+                            {{athleteEntry.event}}
+                        </td>
+                        <td style="min-width:25px">
+                            <span class="medal-icon" [ngClass]="{'bronze': athleteEntry.medal === 'Bronze', 'silver': athleteEntry.medal === 'Silver', 'gold': athleteEntry.medal === 'Gold' }"></span>
+                        </td>
+                    </tr>
+                </ng-template>
+            </p-table>

--- a/src/app/olympic-entries/olympic-entries.component.scss
+++ b/src/app/olympic-entries/olympic-entries.component.scss
@@ -1,0 +1,20 @@
+.medal-icon {
+    height: 25px;
+    width: 25px;
+    background-color: white;
+    border: 1px solid black;
+    border-radius: 50%;
+    display: inline-block;
+  }
+
+  .bronze {
+      background-color: #B08D57;
+  }
+
+  .silver {
+      background-color: #AAA9AD;
+  }
+
+  .gold {
+      background-color: #D4AF37;
+  }

--- a/src/app/olympic-entries/olympic-entries.component.ts
+++ b/src/app/olympic-entries/olympic-entries.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit } from '@angular/core';
+import { FilteredDataService } from '../filtered-data.service';
+
+@Component({
+  selector: 'app-olympic-entries',
+  templateUrl: './olympic-entries.component.html',
+  styleUrls: ['./olympic-entries.component.scss']
+})
+export class OlympicEntriesComponent implements OnInit {
+
+  constructor(public filteredDataService: FilteredDataService) { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/olympic-entries/olympic-entries.component.ts
+++ b/src/app/olympic-entries/olympic-entries.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { AthleteEntry } from 'src/models/athlete-entry';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FilteredDataService } from '../filtered-data.service';
 
 @Component({
@@ -6,11 +7,20 @@ import { FilteredDataService } from '../filtered-data.service';
   templateUrl: './olympic-entries.component.html',
   styleUrls: ['./olympic-entries.component.scss']
 })
-export class OlympicEntriesComponent implements OnInit {
+export class OlympicEntriesComponent implements OnInit, OnDestroy {
+  selectedFilteredAthleteEntries: AthleteEntry[] = []
+  subscription = null;
 
   constructor(public filteredDataService: FilteredDataService) { }
 
   ngOnInit(): void {
+    this.subscription = this.filteredDataService.selectedFilteredAthleteEntriesSubject.subscribe((aes: AthleteEntry[]) => {
+      this.selectedFilteredAthleteEntries = aes;
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
   }
 
 }

--- a/src/app/person-detail/person-detail.component.html
+++ b/src/app/person-detail/person-detail.component.html
@@ -1,68 +1,36 @@
-<div *ngIf="selectedAthlete == null; then emptyBlock else athleteBlock"></div>
+<div *ngIf="selectedAthlete == null; then emptyBlock; else athleteBlock"></div>
 <ng-template #emptyBlock>No athlete selected.</ng-template>
 <ng-template #athleteBlock>
-    <div class="row">
-        <div class="col-4">
-            <h2>{{ selectedAthlete.name }}</h2>
-            <img src="https://www.kindpng.com/picc/m/163-1639541_transparent-running-clipart-png-cartoon-athlete-png-png.png" width="200" height="300">
-            <p>Sex: {{ selectedAthlete.sex }}</p>
-            <p *ngIf="selectedAthlete.birthYear.toString() != 'NaN'">Year of birth: {{ selectedAthlete.birthYear }}</p>
-            <p *ngIf="selectedAthlete.weight.toString() != 'NaN'">Weight: {{ selectedAthlete.weight }}</p>
-            <p *ngIf="selectedAthlete.height.toString() != 'NaN'">Height: {{ selectedAthlete.height }}</p>
-        </div>
-        <div class="card col-md-8">
-            <h5>Olympic entries</h5>
-            <p-table [value]="athleteEntries" sortField="year" [sortOrder]="-1" sortMode="single" [scrollable]="true" scrollHeight="400px" rowGroupMode="subheader" responsiveLayout="scroll">
-                <ng-template pTemplate="header">
-                    <tr>
-                        <th pSortableColumn="year" style="min-width:20px">Year <p-sortIcon field="year"></p-sortIcon></th>
-                        <th pSortableColumn="city" style="min-width:50px">City <p-sortIcon field="city"></p-sortIcon></th>
-                        <th pSortableColumn="sport" style="min-width:250px">Sport <p-sortIcon field="sport"></p-sortIcon></th>
-                        <th pSortableColumn="event" style="min-width:350px">Event <p-sortIcon field="event"></p-sortIcon></th>
-                        <th style="min-width:25px">Medal</th>
-                    </tr>
-                </ng-template>
-                <ng-template pTemplate="groupfooter" let-athleteEntry>
-                    <tr class="p-rowgroup-footer">
-                        <td style="min-width: 80%">
-                            <div style="text-align: right; width: 100%">Total entries: </div>
-                        </td>
-                        <td style="width: 20%">{{athleteEntries.length}}</td>
-                    </tr>
-                </ng-template>
-                <ng-template pTemplate="body" let-athleteEntry let-rowIndex="rowIndex">
-                    <tr>
-                        <td style="min-width:20px">
-                            {{athleteEntry.year}}
-                        </td>
-                        <td style="min-width:50px">
-                            {{athleteEntry.city}}
-                        </td>
-                        <td style="min-width:250px">
-                            {{athleteEntry.sport}}
-                        </td>
-                        <td style="min-width:350px">
-                            {{athleteEntry.event}}
-                        </td>
-                        <td style="min-width:25px">
-                            <span class="medal-icon" [ngClass]="{'bronze': athleteEntry.medal === 'Bronze', 'silver': athleteEntry.medal === 'Silver', 'gold': athleteEntry.medal === 'Gold' }"></span>
-                        </td>
-                    </tr>
-                </ng-template>
-            </p-table>
+  <h2>{{ selectedAthlete.name }}</h2>
 
+  <div class="row">
+    <div class="col-3">
+      <img
+        src="https://www.kindpng.com/picc/m/163-1639541_transparent-running-clipart-png-cartoon-athlete-png-png.png"
+        width="200"
+        height="300"
+      />
+    </div>
+    <div class="col-4">
+      <p>Sex: {{ selectedAthlete.sex }}</p>
+      <p *ngIf="selectedAthlete.birthYear.toString() != 'NaN'">
+        Year of birth: {{ selectedAthlete.birthYear }}
+      </p>
+      <p *ngIf="selectedAthlete.weight.toString() != 'NaN'">
+        Weight: {{ selectedAthlete.weight }}
+      </p>
+      <p *ngIf="selectedAthlete.height.toString() != 'NaN'">
+        Height: {{ selectedAthlete.height }}
+      </p>
+    </div>
 
-        </div>
-        <!--div class="medal-chart col-md-8">
+    <!-- <div class="card col-md-8">
+    </div> -->
+    <!--div class="medal-chart col-md-8">
             <ng-template ngFor let-athleteEntry [ngForOf]="athleteEntries" let-i="index">
                 <h3 *ngIf="i === 0 || athleteEntry.year !== athleteEntries[i-1].year">{{ athleteEntry.year }} - {{ athleteEntry.city }}</h3>
                 <p>{{ athleteEntry.sport }}: {{ athleteEntry.event }} <span class="medal-icon" [ngClass]="{'bronze': athleteEntry.medal === 'Bronze', 'silver': athleteEntry.medal === 'Silver', 'gold': athleteEntry.medal === 'Gold' }"></span></p>
             </ng-template>
         </div-->
-
-       
-    </div>
+  </div>
 </ng-template>
-
-
-

--- a/src/app/person-detail/person-detail.component.ts
+++ b/src/app/person-detail/person-detail.component.ts
@@ -9,6 +9,7 @@ import { AthleteEntry } from 'src/models/athlete-entry';
   styleUrls: ['./person-detail.component.scss']
 })
 export class PersonDetailComponent implements OnInit {
+  private _medalsSubscription: any;
 
   constructor(public filteredDataService: FilteredDataService) { }
 
@@ -16,6 +17,8 @@ export class PersonDetailComponent implements OnInit {
   private _subscriptionEntries;
   public selectedAthlete: Athlete;
   public athleteEntries: AthleteEntry[];
+  public medalData: number[] = [];
+
 
   ngOnDestroy(): void {
     if (this._subscription) {
@@ -24,9 +27,13 @@ export class PersonDetailComponent implements OnInit {
     if (this._subscriptionEntries) {
       this._subscriptionEntries.unsubscribe();
     }
+    if (this._medalsSubscription) {
+      this._subscription.unsubscribe();
+    }
   }
 
   ngOnInit(): void {
+    this.setMedalsData();
     this._subscription = this.filteredDataService.selectedAthleteSubject.subscribe(
       athlete => {
         this.selectedAthlete = athlete;
@@ -52,6 +59,21 @@ export class PersonDetailComponent implements OnInit {
     }
 
     return total;
+  }
+
+
+  private setMedalsData() {
+    const countOccurrences = (arr, val) => arr.reduce((a, v) => (v.medal === val ? a + 1 : a), 0);
+    this._medalsSubscription = this.filteredDataService.filteredAthletesSubject.subscribe(
+      fa => {
+        let goldCount = countOccurrences(fa, "Gold");
+        //console.log('gold count is ' + goldCount);
+        let silverCount = countOccurrences(fa, "Silver");
+        //console.log('silver count is ' + silverCount);
+        let bronzeCount = countOccurrences(fa, "Bronze");
+        this.medalData = [goldCount, silverCount, bronzeCount];
+      }
+    );
   }
 
 }

--- a/src/app/person-detail/person-detail.component.ts
+++ b/src/app/person-detail/person-detail.component.ts
@@ -64,14 +64,19 @@ export class PersonDetailComponent implements OnInit {
 
   private setMedalsData() {
     const countOccurrences = (arr, val) => arr.reduce((a, v) => (v.medal === val ? a + 1 : a), 0);
-    this._medalsSubscription = this.filteredDataService.filteredAthletesSubject.subscribe(
+    this._medalsSubscription = this.filteredDataService.selectedFilteredAthletesSubject.subscribe(
       fa => {
-        let goldCount = countOccurrences(fa, "Gold");
-        //console.log('gold count is ' + goldCount);
-        let silverCount = countOccurrences(fa, "Silver");
-        //console.log('silver count is ' + silverCount);
-        let bronzeCount = countOccurrences(fa, "Bronze");
-        this.medalData = [goldCount, silverCount, bronzeCount];
+        if (fa) {
+          let goldCount = countOccurrences(fa, "Gold");
+          //console.log('gold count is ' + goldCount);
+          let silverCount = countOccurrences(fa, "Silver");
+          //console.log('silver count is ' + silverCount);
+          let bronzeCount = countOccurrences(fa, "Bronze");
+          this.medalData = [goldCount, silverCount, bronzeCount];
+        }
+        else {
+          this.medalData = [0,0,0];
+        } 
       }
     );
   }

--- a/src/app/person-detail/person-detail.component.ts
+++ b/src/app/person-detail/person-detail.component.ts
@@ -39,7 +39,7 @@ export class PersonDetailComponent implements OnInit {
         this.selectedAthlete = athlete;
       }
     );
-    this._subscriptionEntries = this.filteredDataService.selectedFilteredAthletesSubject.subscribe(
+    this._subscriptionEntries = this.filteredDataService.selectedFilteredAthleteEntriesSubject.subscribe(
       athleteEntries => {
         this.athleteEntries = athleteEntries;
         // this.refreshTable();
@@ -64,7 +64,7 @@ export class PersonDetailComponent implements OnInit {
 
   private setMedalsData() {
     const countOccurrences = (arr, val) => arr.reduce((a, v) => (v.medal === val ? a + 1 : a), 0);
-    this._medalsSubscription = this.filteredDataService.selectedFilteredAthletesSubject.subscribe(
+    this._medalsSubscription = this.filteredDataService.selectedFilteredAthleteEntriesSubject.subscribe(
       fa => {
         if (fa) {
           let goldCount = countOccurrences(fa, "Gold");

--- a/src/app/related-graph-country-medals/related-graph-country-medals.component.ts
+++ b/src/app/related-graph-country-medals/related-graph-country-medals.component.ts
@@ -1,3 +1,4 @@
+import { DisciplineEntry } from 'src/models/discipline-entry';
 import { Component, OnInit } from '@angular/core';
 import { Athlete } from 'src/models/athlete';
 import { FilterService } from '../filter.service';
@@ -10,26 +11,45 @@ import { FilteredDataService } from '../filtered-data.service';
 })
 export class RelatedGraphCountryMedalsComponent implements OnInit {
 
-  private _subscription;
+  private subscriptions = [];
   public selectedAthlete: Athlete;
+  public selectedDiscipline: DisciplineEntry;
+  public chosenEdition: string;
   stackedMedalData: any;
   stackedMedalOptions: any;
+  chosenSex: any;
 
   constructor(public filteredDataService: FilteredDataService, public filterService: FilterService) { }
 
   ngOnDestroy(): void {
-    if (this._subscription) {
-      this._subscription.unsubscribe();
-    }
+    this.subscriptions.forEach(s => s.unsubscribe());
   }
 
   ngOnInit(): void {
-    this._subscription = this.filteredDataService.selectedAthleteSubject.subscribe(
+    this.subscriptions.push(this.filteredDataService.selectedAthleteSubject.subscribe(
       athlete => {
         this.selectedAthlete = athlete;
         this.buildCountryMedals();
       }
-    );
+    ));
+    this.subscriptions.push(this.filteredDataService.selectedDisciplinesSubject.subscribe(
+      discipline => {
+        this.selectedDiscipline = discipline;
+        this.buildCountryMedals();
+      }
+    ));
+    this.subscriptions.push(this.filteredDataService.chosenEditionSubject.subscribe(
+      edition => {
+        this.chosenEdition = edition;
+        this.buildCountryMedals();
+      }
+    ));
+    this.subscriptions.push(this.filteredDataService.chosenSexSubject.subscribe(
+      sex => {
+        this.chosenSex = sex;
+        this.buildCountryMedals();
+      }
+    ));
     this.buildCountryMedals();
   }
 
@@ -50,7 +70,7 @@ export class RelatedGraphCountryMedalsComponent implements OnInit {
     let goldList: number[] = [];
     if (this.selectedAthlete) {
       // this service method returns [bronzeDict, silverDict, goldDict]-dictionaries, they have an easy way to retrieve gold medals for year X: e.g. X = 2020, desired type is gold medals: goldDict.2020
-      let resultList = this.filterService.calculateMedalsForCountryForYearRange(this.selectedAthlete.noc, this.filterService.yearRange[0], this.filterService.yearRange[1]);
+      let resultList = this.filterService.calculateMedalsForCountryForYearRange(this.selectedAthlete.noc, this.filterService.yearRange[0], this.filterService.yearRange[1], this.selectedDiscipline, this.chosenEdition, this.chosenSex);
       console.log(resultList);
       let bronzeEntries: Map<number, number> = resultList[0];
       let silverEntries: Map<number, number> = resultList[1];

--- a/src/app/related-graphs/related-graphs.component.html
+++ b/src/app/related-graphs/related-graphs.component.html
@@ -1,5 +1,9 @@
 <p-tabView>
-  <p-tabPanel header="Country Medals" [selected]="true">
+  <p-tabPanel header="Olympic Entries" [selected]="true">
+    <app-olympic-entries></app-olympic-entries>
+  </p-tabPanel>
+
+  <p-tabPanel header="Country Medals">
     <app-related-graph-country-medals></app-related-graph-country-medals>
   </p-tabPanel>
   <p-tabPanel header="To Create">Just a placeholder...</p-tabPanel>

--- a/src/app/related-graphs/related-graphs.component.html
+++ b/src/app/related-graphs/related-graphs.component.html
@@ -1,10 +1,9 @@
 <p-tabView>
-  <p-tabPanel *ngIf="selectedAthlete" header="Olympic Entries" >
+  <p-tabPanel *ngIf="selectedAthlete" header="Olympic Entries" [selected]="selectedAthlete" >
     <app-olympic-entries></app-olympic-entries>
   </p-tabPanel>
 
-  <p-tabPanel header="Country Medals">
+  <p-tabPanel header="Country Medals" [selected]="!selectedAthlete">
     <app-related-graph-country-medals></app-related-graph-country-medals>
   </p-tabPanel>
-  <p-tabPanel header="To Create">Just a placeholder...</p-tabPanel>
 </p-tabView>

--- a/src/app/related-graphs/related-graphs.component.html
+++ b/src/app/related-graphs/related-graphs.component.html
@@ -1,5 +1,5 @@
 <p-tabView>
-  <p-tabPanel header="Olympic Entries" [selected]="true">
+  <p-tabPanel *ngIf="selectedAthlete" header="Olympic Entries" >
     <app-olympic-entries></app-olympic-entries>
   </p-tabPanel>
 

--- a/src/app/related-graphs/related-graphs.component.ts
+++ b/src/app/related-graphs/related-graphs.component.ts
@@ -1,18 +1,31 @@
-import { Component, OnInit } from '@angular/core';
+import { AthleteEntry } from 'src/models/athlete-entry';
+import { FilteredDataService } from './../filtered-data.service';
+import { FilterService } from './../filter.service';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Athlete } from 'src/models/athlete';
 
 @Component({
   selector: 'app-related-graphs',
   templateUrl: './related-graphs.component.html',
   styleUrls: ['./related-graphs.component.scss']
 })
-export class RelatedGraphsComponent implements OnInit {
+export class RelatedGraphsComponent implements OnInit, OnDestroy {
 
- 
+  selectedAthlete: Athlete;
+  subscription = null;
 
-  constructor() { 
-   
+  constructor(private filteredDataService: FilteredDataService) { 
+    this.subscription = this.filteredDataService.selectedAthleteSubject.subscribe(sa => {
+      this.selectedAthlete = sa;
+    });
   }
 
   ngOnInit(): void {
+  }
+
+  ngOnDestroy(): void {
+    if (this.subscription) {
+      this.subscription.unsubsribe();
+    }
   }
 }

--- a/src/app/selection/selection.component.html
+++ b/src/app/selection/selection.component.html
@@ -1,5 +1,5 @@
 <div class="row">
-    <p-virtualScroller [value]="filteredDataService.filteredAthletes2Subject" [lazy]="true" (onLazyLoad)="loadPersonsLazy($event)" scrollHeight="500px" [itemSize]="25" [rows]="10">
+    <p-virtualScroller [value]="filteredDataService.filteredAthletesSubject" [lazy]="true" (onLazyLoad)="loadPersonsLazy($event)" scrollHeight="500px" [itemSize]="25" [rows]="10">
       <ng-template pTemplate="header">Athletes</ng-template>
       {{selectedAthlete}}
       <ng-template pTemplate="item" let-person>

--- a/src/app/selection/selection.component.html
+++ b/src/app/selection/selection.component.html
@@ -13,11 +13,11 @@
     </p-virtualScroller>
 </div>
 <div class="row">
-    <p-virtualScroller [value]="filteredDataService.filteredCountriesSubject" scrollHeight="500px" [itemSize]="25">
-      <ng-template pTemplate="header">Countries</ng-template>
-      <ng-template pTemplate="item" let-country>
+    <p-virtualScroller [value]="filteredDataService.filteredDisciplinesSubject" scrollHeight="500px" [itemSize]="25">
+      <ng-template pTemplate="header">Disciplines</ng-template>
+      <ng-template pTemplate="item" let-discipline>
         <div class="country-entry">
-          {{country}}
+          {{discipline.event}}
         </div>
       </ng-template>
     </p-virtualScroller>

--- a/src/app/selection/selection.component.html
+++ b/src/app/selection/selection.component.html
@@ -3,7 +3,7 @@
       <ng-template pTemplate="header">Athletes</ng-template>
       {{selectedAthlete}}
       <ng-template pTemplate="item" let-person>
-          <div class="person-entry" [ngClass]="{'selected-item': selectedAthlete && selectedAthlete.name === person}" (click)="this.filterService.searchAndSelectFirstAthleteEntryByName(person)">
+          <div class="person-entry" [ngClass]="{'selected-item': selectedAthlete && selectedAthlete.name === person}" (click)="filterService.searchAndSelectFirstAthleteEntryByName(person)">
             {{person}}
           </div>
       </ng-template>
@@ -13,15 +13,25 @@
     </p-virtualScroller>
 </div>
 <div class="row">
-    <p-virtualScroller [value]="disciplines | keyvalue" scrollHeight="500px" [itemSize]="25">
-      <ng-template pTemplate="header">Disciplines</ng-template>
-      <ng-template pTemplate="item" let-discipline>
-        <div class="country-entry" style="font-weight: bold;">
-          {{discipline.key}}
-        </div>
-        <div *ngFor="let value of discipline.value">
-          {{value.event}}
-        </div>
-      </ng-template>
-    </p-virtualScroller>
+  <p-table [value]="filteredDataService.filteredDisciplinesSubject | async" sortField="sport" sortMode="single" [scrollable]="true" scrollHeight="500px" rowGroupMode="subheader" groupRowsBy="sport" responsiveLayout="scroll">
+        <ng-template pTemplate="header">
+          <tr>
+            <th>Disciplines</th>
+          </tr>
+        </ng-template>
+        <ng-template pTemplate="groupheader" let-discipline>
+            <tr pRowGroupHeader>
+                <td colspan="5" style="border: none; padding: 0;" class="person-entry">
+                    <span class="font-bold ml-2" style="font-weight: bold; margin-top: 15px; margin-bottom: 5px;">{{discipline.sport}}</span>
+                </td>
+            </tr>
+        </ng-template>
+        <ng-template pTemplate="body" let-discipline let-rowIndex="rowIndex">
+            <tr (click)="filterService.searchAndSelectFirstDiscipline(discipline)">
+                <td style="min-width:200px; border: none; padding: 0" class="person-entry">
+                    {{discipline.event}}
+                </td>
+            </tr>
+        </ng-template>
+    </p-table>
 </div>

--- a/src/app/selection/selection.component.html
+++ b/src/app/selection/selection.component.html
@@ -27,7 +27,7 @@
             </tr>
         </ng-template>
         <ng-template pTemplate="body" let-discipline let-rowIndex="rowIndex">
-            <tr (click)="filterService.searchAndSelectFirstDiscipline(discipline)" [ngClass]="{'selected-item': selectedDiscipline && selectedDiscipline.equals(discipline)}">
+            <tr (click)="filterService.searchAndSelectFirstDiscipline(discipline)" [ngClass]="{'selected-item': selectedDiscipline && disciplineEntriesEqual(selectedDiscipline, discipline)}">
                 <td style="min-width:200px; border: none; padding: 0" class="person-entry">
                     {{discipline.event}}
                 </td>

--- a/src/app/selection/selection.component.html
+++ b/src/app/selection/selection.component.html
@@ -13,11 +13,14 @@
     </p-virtualScroller>
 </div>
 <div class="row">
-    <p-virtualScroller [value]="filteredDataService.filteredDisciplinesSubject" scrollHeight="500px" [itemSize]="25">
+    <p-virtualScroller [value]="disciplines | keyvalue" scrollHeight="500px" [itemSize]="25">
       <ng-template pTemplate="header">Disciplines</ng-template>
       <ng-template pTemplate="item" let-discipline>
-        <div class="country-entry">
-          {{discipline.event}}
+        <div class="country-entry" style="font-weight: bold;">
+          {{discipline.key}}
+        </div>
+        <div *ngFor="let value of discipline.value">
+          {{value.event}}
         </div>
       </ng-template>
     </p-virtualScroller>

--- a/src/app/selection/selection.component.html
+++ b/src/app/selection/selection.component.html
@@ -1,10 +1,10 @@
 <div class="row">
-    <p-virtualScroller [value]="filteredDataService.filteredPersonsSubject" [lazy]="true" (onLazyLoad)="loadPersonsLazy($event)" scrollHeight="500px" [itemSize]="25" [rows]="10">
+    <p-virtualScroller [value]="filteredDataService.filteredAthletes2Subject" [lazy]="true" (onLazyLoad)="loadPersonsLazy($event)" scrollHeight="500px" [itemSize]="25" [rows]="10">
       <ng-template pTemplate="header">Athletes</ng-template>
       {{selectedAthlete}}
       <ng-template pTemplate="item" let-person>
-          <div class="person-entry" [ngClass]="{'selected-item': selectedAthlete && selectedAthlete.name === person}" (click)="filterService.searchAndSelectFirstAthleteEntryByName(person)">
-            {{person}}
+          <div class="person-entry" [ngClass]="{'selected-item': selectedAthlete && selectedAthlete.name === person.name}" (click)="filterService.searchAndSelectFirstAthleteEntryByName(person.name)">
+            {{person.name}}
           </div>
       </ng-template>
       <ng-template let-person pTemplate="loadingItem">
@@ -27,7 +27,7 @@
             </tr>
         </ng-template>
         <ng-template pTemplate="body" let-discipline let-rowIndex="rowIndex">
-            <tr (click)="filterService.searchAndSelectFirstDiscipline(discipline)">
+            <tr (click)="filterService.searchAndSelectFirstDiscipline(discipline)" [ngClass]="{'selected-item': selectedDiscipline && selectedDiscipline.equals(discipline)}">
                 <td style="min-width:200px; border: none; padding: 0" class="person-entry">
                     {{discipline.event}}
                 </td>

--- a/src/app/selection/selection.component.html
+++ b/src/app/selection/selection.component.html
@@ -27,8 +27,8 @@
             </tr>
         </ng-template>
         <ng-template pTemplate="body" let-discipline let-rowIndex="rowIndex">
-            <tr (click)="filterService.searchAndSelectFirstDiscipline(discipline)" [ngClass]="{'selected-item': selectedDiscipline && disciplineEntriesEqual(selectedDiscipline, discipline)}">
-                <td style="min-width:200px; border: none; padding: 0" class="person-entry">
+            <tr (click)="filterService.searchAndSelectFirstDiscipline(discipline)">
+                <td style="min-width:200px; border: none; padding: 0; padding-left: 10px;" class="person-entry" [ngClass]="{'selected-item': selectedDiscipline && disciplineEntriesEqual(selectedDiscipline, discipline)}">
                     {{discipline.event}}
                 </td>
             </tr>

--- a/src/app/selection/selection.component.ts
+++ b/src/app/selection/selection.component.ts
@@ -18,9 +18,11 @@ export class SelectionComponent implements OnInit {
   private _subscription;
   private _subscriptionSelectedAthlete;
   private _disciplinesSubscription;
+  private _selectedDisciplineSubscription: any;
   people: string[] = [];
   virtualPeople: string[];
   selectedAthlete: Athlete;
+  selectedDiscipline: DisciplineEntry;
   disciplines = {};
 
   ngOnDestroy(): void {
@@ -30,13 +32,19 @@ export class SelectionComponent implements OnInit {
     if (this._subscriptionSelectedAthlete) {
       this._subscriptionSelectedAthlete.unsubscribe();
     }
+    if (this._disciplinesSubscription) {
+      this._disciplinesSubscription.unsubscribe();
+    }
+    if (this._selectedDisciplineSubscription) {
+      this._selectedDisciplineSubscription.unsubscribe();
+    }
   }
 
   ngOnInit(): void {
-    this._subscription = this.filteredDataService.filteredPersonsSubject.subscribe(
+    this._subscription = this.filteredDataService.filteredAthletes2Subject.subscribe(
       fa => {
-        fa.forEach(athleteEntry => {
-          this.people.push(athleteEntry);
+        fa.forEach((athlete: Athlete) => {
+          this.people.push(athlete.name);
         });
       }
     );
@@ -47,6 +55,9 @@ export class SelectionComponent implements OnInit {
     );
     this._disciplinesSubscription = this.filteredDataService.filteredDisciplinesSubject.subscribe(d => {
       this.disciplines = this.groupDisciplines(d);
+    })
+    this._selectedDisciplineSubscription = this.filteredDataService.selectedDisciplinesSubject.subscribe(d => {
+      this.selectedDiscipline = d;
     })
     this.virtualPeople = Array.from({length: 100});
   }

--- a/src/app/selection/selection.component.ts
+++ b/src/app/selection/selection.component.ts
@@ -1,3 +1,4 @@
+import { DisciplineEntry } from 'src/models/discipline-entry';
 import { FilteredDataService } from './../filtered-data.service';
 import { FilterService } from './../filter.service';
 import { Component, OnInit } from '@angular/core';
@@ -16,9 +17,11 @@ export class SelectionComponent implements OnInit {
   //private velden voor deze class
   private _subscription;
   private _subscriptionSelectedAthlete;
+  private _disciplinesSubscription;
   people: string[] = [];
   virtualPeople: string[];
   selectedAthlete: Athlete;
+  disciplines = {};
 
   ngOnDestroy(): void {
     if (this._subscription) {
@@ -42,6 +45,9 @@ export class SelectionComponent implements OnInit {
         this.selectedAthlete = fa;
       }
     );
+    this._disciplinesSubscription = this.filteredDataService.filteredDisciplinesSubject.subscribe(d => {
+      this.disciplines = this.groupDisciplines(d);
+    })
     this.virtualPeople = Array.from({length: 100});
   }
 
@@ -55,6 +61,15 @@ export class SelectionComponent implements OnInit {
       
       //trigger change detection
       this.virtualPeople = [...this.virtualPeople];
+  }
+
+  private groupDisciplines(disciplines: DisciplineEntry[]) {
+    return disciplines.reduce((groups, item) => {
+      const val = item.sport;
+      groups[val] = groups[val] || [];
+      groups[val].push(item);
+      return groups;
+    }, {});
   }
 
 }

--- a/src/app/selection/selection.component.ts
+++ b/src/app/selection/selection.component.ts
@@ -41,7 +41,7 @@ export class SelectionComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this._subscription = this.filteredDataService.filteredAthletes2Subject.subscribe(
+    this._subscription = this.filteredDataService.filteredAthletesSubject.subscribe(
       fa => {
         fa.forEach((athlete: Athlete) => {
           this.people.push(athlete.name);

--- a/src/app/selection/selection.component.ts
+++ b/src/app/selection/selection.component.ts
@@ -83,4 +83,12 @@ export class SelectionComponent implements OnInit {
     }, {});
   }
 
+  public disciplineEntriesEqual(disciplineEntry1: DisciplineEntry, disciplineEntry2: DisciplineEntry): boolean {
+    let result = disciplineEntry1.sport === disciplineEntry2.sport && disciplineEntry1.event === disciplineEntry2.event && disciplineEntry1.sex === disciplineEntry2.sex;
+    if (result) {
+      return true;
+    }
+    return false;
+  }
+
 }

--- a/src/helpers/discipline-sort-function.ts
+++ b/src/helpers/discipline-sort-function.ts
@@ -1,0 +1,11 @@
+import { DisciplineEntry } from 'src/models/discipline-entry';
+
+export function disciplineSortFunction(disciplineA: DisciplineEntry, disciplineB: DisciplineEntry) {
+    if (disciplineA.sport === disciplineB.sport) {
+        return 0;
+    }
+    if (disciplineA.sport < disciplineB.sport) {
+        return -1
+    }
+    return 1;
+}

--- a/src/models/athlete-entry.ts
+++ b/src/models/athlete-entry.ts
@@ -1,3 +1,4 @@
+import { DisciplineEntry } from './discipline-entry';
 export class AthleteEntry {
     id: number;
     name: string;
@@ -11,9 +12,8 @@ export class AthleteEntry {
     year: number;
     season: string;
     city: string;
-    sport: string;
-    event: string;
     medal: string;
+    disciplineEntry: DisciplineEntry;
 
     constructor(id: number, name: string, sex: string, age: number, height: number, weight: number, team: string, noc: string, games: string, year: number, season: string, city: string, sport: string, event: string, medal: string) {
         this.id = id;
@@ -28,8 +28,7 @@ export class AthleteEntry {
         this.year = year;
         this.season = season;
         this.city = city;
-        this.sport = sport;
-        this.event = event;
         this.medal = medal;
+        this.disciplineEntry = new DisciplineEntry(sport, event, sex);
     }
 }

--- a/src/models/csv-data.ts
+++ b/src/models/csv-data.ts
@@ -1,13 +1,15 @@
+import { DisciplineEntry } from './discipline-entry';
 import { AthleteEntry } from './athlete-entry';
 import { Athlete } from './athlete';
 import { NOCRegionEntry } from './noc-region-entry';
 
 export class CsvData {
-    nocRegionEntries: NOCRegionEntry[];
-    athleteEntries: AthleteEntry[];
-    countries: string[];
-    persons: string[];
-    athletes: Athlete[];
+    nocRegionEntries: NOCRegionEntry[] = [];
+    athleteEntries: AthleteEntry[] = [];
+    disciplineEntries: DisciplineEntry[] = [];
+    countries: string[] = [];
+    persons: string[] = [];
+    athletes: Athlete[] = [];
 
 
     constructor(nocRegionEntries: NOCRegionEntry[],
@@ -17,6 +19,14 @@ export class CsvData {
         athletes: Athlete[]) {
         this.nocRegionEntries = nocRegionEntries;
         this.athleteEntries = athleteEntries;
+        let disciplineSet: Set<string> = new Set<string>();
+        this.athleteEntries.forEach(ae => {
+            let disciplineString = `${ae.disciplineEntry.event}${ae.disciplineEntry.sport}${ae.disciplineEntry.sex}`;
+            if (!disciplineSet.has(disciplineString)) {
+                this.disciplineEntries.push(new DisciplineEntry(ae.disciplineEntry.sport, ae.disciplineEntry.event, ae.disciplineEntry.sex))
+                disciplineSet.add(disciplineString);
+            }
+        })
         this.countries = countries;
         this.persons = persons;
         this.athletes = athletes;

--- a/src/models/discipline-entry.ts
+++ b/src/models/discipline-entry.ts
@@ -8,13 +8,5 @@ export class DisciplineEntry {
         this.event = event;
         this.sex = sex;
     }
-
-    public equals(disciplineEntry: DisciplineEntry):boolean {
-        let result = this.sport === disciplineEntry.sport && this.event === disciplineEntry.event && this.sex === disciplineEntry.sex;
-        if (result) {
-            return true;
-        }
-        return false;
-    }
 }
 

--- a/src/models/discipline-entry.ts
+++ b/src/models/discipline-entry.ts
@@ -1,0 +1,11 @@
+export class DisciplineEntry {
+    sport: string;
+    event: string;
+    sex: string;
+
+    constructor(sport: string, event: string, sex: string) {
+        this.sport = sport;
+        this.event = event;
+        this.sex = sex;
+    }
+}

--- a/src/models/discipline-entry.ts
+++ b/src/models/discipline-entry.ts
@@ -8,5 +8,13 @@ export class DisciplineEntry {
         this.event = event;
         this.sex = sex;
     }
+
+    public equals(disciplineEntry2: DisciplineEntry): boolean {
+        let result = this.sport === disciplineEntry2.sport && this.event === disciplineEntry2.event && this.sex === disciplineEntry2.sex;
+        if (result) {
+            return true;
+        }
+        return false;
+    }
 }
 

--- a/src/models/discipline-entry.ts
+++ b/src/models/discipline-entry.ts
@@ -9,3 +9,4 @@ export class DisciplineEntry {
         this.sex = sex;
     }
 }
+

--- a/src/models/discipline-entry.ts
+++ b/src/models/discipline-entry.ts
@@ -8,5 +8,13 @@ export class DisciplineEntry {
         this.event = event;
         this.sex = sex;
     }
+
+    public equals(disciplineEntry: DisciplineEntry):boolean {
+        let result = this.sport === disciplineEntry.sport && this.event === disciplineEntry.event && this.sex === disciplineEntry.sex;
+        if (result) {
+            return true;
+        }
+        return false;
+    }
 }
 


### PR DESCRIPTION
Countries in selectiecomponent vervangen door de disciplines.

Discipline selecteren gaat. Dit zorgt ervoor dat enkel de Atleten nog zichtbaar zijn die deelgenomen hebben aan de geselecteerde discipline.

Disciplinelijst wordt momenteel nog niet gefilterd op basis van de geselecteerde atleet.

Wanneer discipline aangeklikt wordt, worden de Atleten gefilterd op basis van de geselecteerde Discipline, maar alle andere Disciplines verdijwenen ui de disciplinelijst. 

=> Ga proberen dit doorheen de week nog allemaal te fixen, maar zo kunnen we al een visualisatie proberen maken.